### PR TITLE
feature(cli): adding --directory=PATH to generate distributable HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ in the bundle (perhaps because of out-of-date dependencies).
     source-map-explorer --html foo.min.js > tree.html
     ```
     
+* `--directory`: writes HTML to a directory that also includes all assets required to load the visualization in a browser. The specified directory is resolved agains the current working directory (CWD):
+
+    ```
+    source-map-explorer --directory ./bundle-size
+    ```
+
 * `--replace`, `--with`: The paths in source maps sometimes have artifacts that are difficult to get rid of. These flags let you do simple find & replaces on the paths. For example:
 
     ```

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "convert-source-map": "^1.1.1",
     "docopt": "^0.6.2",
     "file-url": "^1.0.1",
+    "fs-extra": "^0.26.7",
     "open": "0.0.5",
     "source-map": "^0.5.1",
     "temp": "^0.8.3",


### PR DESCRIPTION
covers #28 by adding `--directory=PATH` to the CLI. If this option is specified, the HTML file is written to `<path>/index.html` and the resources (`underscore.js`, `webtreemap.js`, `webtreemap.css`) are copied to the directory.

As your test suite does not cover the CLI params, I've not added tests.