### PR TITLE
feature(cli): adding --root=PATH to specify common source path

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ in the bundle (perhaps because of out-of-date dependencies).
 
 * `--noroot`: By default, source-map-explorer finds common prefixes between all source files and eliminates them, since they add complexity to the visualization with no real benefit. But if you want to disable this behavior, set the `--noroot` flag.
 
+* `--root`: Truncate source file paths to a given root. The specified path is resolved agains the current working directory (CWD):
+
+    ```
+    source-map-explorer dist/foo.min.js --root './dist'
+    ```
+
 ## Generating source maps
 
 For source-map-explorer to be useful, you need to generate a source map which

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var doc = [
 '',
 'Usage:',
 '  source-map-explorer <script.js> [<script.js.map>]',
-'  source-map-explorer [--json | --html | --tsv] <script.js> [<script.js.map>] [--replace=BEFORE --with=AFTER]... [--noroot]',
+'  source-map-explorer [--json | --html | --tsv] <script.js> [<script.js.map>] [--replace=BEFORE --with=AFTER]... [--noroot] [--root=PATH]',
 '  source-map-explorer -h | --help | --version',
 '',
 'If the script file has an inline source map, you may omit the map parameter.',
@@ -23,6 +23,8 @@ var doc = [
 '   --noroot  To simplify the visualization, source-map-explorer',
 '             will remove any prefix shared by all sources. If you',
 '             wish to disable this behavior, set --noroot.',
+'',
+'   --root=PATH  truncate paths to a given root',
 '',
 '  --replace=BEFORE  Apply a simple find/replace on source file',
 '                    names. This can be used to fix some oddities',
@@ -171,6 +173,12 @@ if (_.size(sizes) == 1) {
   console.error("This can happen if you use browserify+uglifyjs, for example, and don't set the --in-source-map flag to uglify.");
   console.error('See ', SOURCE_MAP_INFO_URL);
   process.exit(1);
+}
+
+if (args['--root']) {
+  var basePath = path.resolve(process.cwd(), args['--root'] || '.') + '/';
+  args['--replace'].push(basePath);
+  args['--with'].push('');
 }
 
 sizes = adjustSourcePaths(sizes, !args['--noroot'], args['--replace'], args['--with']);


### PR DESCRIPTION
In order to combat weird output caused by SourceMaps referencing `node_modules/*` instead of `/path/to/project/node_modules/*` and having to specify `/path/to/project/` in a `--replace` argument, the `--root` option allows to specify the common root.

I used to do this as follows, without realising, that the `process.cwd()` would not necessarily match:

``` bash
source-map-explorer dist/bundle.min.js \
  --replace "`node -e 'console.log(process.cwd())'`/dist/" --with '' \
  --html > reports/bundle-size.html
```

With this change I can run the following and not think about directories anymore:

``` bash
source-map-explorer dist/bundle.min.js --root=dist \
  --html > reports/bundle-size.html
```
