### PR TITLE
Flag to use regular expressions in replace flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/danvk/source-map-explorer.svg?branch=v1.1.0)](https://travis-ci.org/danvk/source-map-explorer) [![NPM version](http://img.shields.io/npm/v/source-map-explorer.svg)](https://www.npmjs.org/package/source-map-explorer)
-# source-map-explorer 
+# source-map-explorer
 Analyze and debug JavaScript code bloat through source maps.
 
 The source map explorer determines which file each byte in your minified JS came from. It shows you a [treemap][] visualization to help you debug where all the code is coming from.
@@ -11,7 +11,7 @@ Install:
 Use:
 
     source-map-explorer bundle.min.js
-    source-map-explorer bundle.min.js bundle.min.js.map 
+    source-map-explorer bundle.min.js bundle.min.js.map
 
 This will open up a visualization of how the space is used in your minified bundle:
 
@@ -34,7 +34,7 @@ in the bundle (perhaps because of out-of-date dependencies).
       "foo.js": 137
     }
     ```
-    
+
 * `--tsv`: output tab-delimited values instead of displaying a visualization:
 
     ```
@@ -43,7 +43,7 @@ in the bundle (perhaps because of out-of-date dependencies).
     dist/bar.js	62
     dist/foo.js	137
     ```
-    
+
     If you just want a list of files, you can do `source-map-explorer --tsv foo.min.js | sed 1d | cut -f1`.
 
 * `--html`: output HTML to stdout. By default, source-map-explorer writes HTML to a temporary file and opens it in your default browser. If you want to save the output (e.g. to share), pipe it to a file:
@@ -51,16 +51,18 @@ in the bundle (perhaps because of out-of-date dependencies).
     ```
     source-map-explorer --html foo.min.js > tree.html
     ```
-    
+
 * `--replace`, `--with`: The paths in source maps sometimes have artifacts that are difficult to get rid of. These flags let you do simple find & replaces on the paths. For example:
 
     ```
     source-map-explorer foo.min.js --replace 'dist/' --with ''
     ```
-    
+
     You can specify these flags multiple times. Be aware that the find/replace is done _after_ eliminating shared prefixes between paths.
 
 * `--noroot`: By default, source-map-explorer finds common prefixes between all source files and eliminates them, since they add complexity to the visualization with no real benefit. But if you want to disable this behavior, set the `--noroot` flag.
+
+* `--noregex`: By default, source-map-explorer treats the `--replace` text as a regular expression. To disable this behavior, set the `--noregex` flag.
 
 ## Generating source maps
 

--- a/index.js
+++ b/index.js
@@ -27,9 +27,9 @@ var doc = [
 '  --replace=BEFORE  Apply a simple find/replace on source file',
 '                    names. This can be used to fix some oddities',
 '                    with paths which appear in the source map',
-'                    generation process.',
+'                    generation process.  Accepts regular expressions.',
 '      --with=AFTER  See --replace.',
-'  --regex  Consider each replace flag as a regular expression.',
+'  --noregex  Do not consider each replace flag as a regular expression.',
 ].join('\n');
 
 var fs = require('fs'),
@@ -125,7 +125,7 @@ function mapKeys(obj, fn) {
   return _.object(_.map(obj, function(v, k) { return [fn(k), v]; }));
 }
 
-function adjustSourcePaths(sizes, findRoot, finds, replaces) {
+function adjustSourcePaths(sizes, findRoot, finds, replaces, regexp) {
   if (findRoot) {
     var prefix = commonPathPrefix(_.keys(sizes));
     var len = prefix.length;
@@ -135,7 +135,7 @@ function adjustSourcePaths(sizes, findRoot, finds, replaces) {
   }
 
   for (var i = 0; i < finds.length; i++) {
-    var before = finds[i],
+    var before = regexp ? new RegExp(finds[i]) : finds[i],
         after = replaces[i];
     sizes = mapKeys(sizes, function(source) {
       return source.replace(before, after);
@@ -175,13 +175,7 @@ if (_.size(sizes) == 1) {
   process.exit(1);
 }
 
-if (args['--regex']) {
-  args['--replace'] = args['--replace'].map(function(x) {
-    return new RegExp(x)
-  });
-}
-
-sizes = adjustSourcePaths(sizes, !args['--noroot'], args['--replace'], args['--with']);
+sizes = adjustSourcePaths(sizes, !args['--noroot'], args['--replace'], args['--with'], !args['--regex']);
 
 if (args['--json']) {
   console.log(JSON.stringify(sizes, null, '  '));

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var doc = [
 '',
 'Usage:',
 '  source-map-explorer <script.js> [<script.js.map>]',
-'  source-map-explorer [--json | --html | --tsv] <script.js> [<script.js.map>] [--replace=BEFORE --with=AFTER]... [--noroot]',
+'  source-map-explorer [--json | --html | --tsv] <script.js> [<script.js.map>] [--replace=BEFORE --with=AFTER]... [--noroot] [--regex]',
 '  source-map-explorer -h | --help | --version',
 '',
 'If the script file has an inline source map, you may omit the map parameter.',
@@ -29,6 +29,7 @@ var doc = [
 '                    with paths which appear in the source map',
 '                    generation process.',
 '      --with=AFTER  See --replace.',
+'  --regex  Consider each replace flag as a regular expression.',
 ].join('\n');
 
 var fs = require('fs'),
@@ -172,6 +173,12 @@ if (_.size(sizes) == 1) {
   console.error("This can happen if you use browserify+uglifyjs, for example, and don't set the --in-source-map flag to uglify.");
   console.error('See ', SOURCE_MAP_INFO_URL);
   process.exit(1);
+}
+
+if (args['--regex']) {
+  args['--replace'] = args['--replace'].map(function(x) {
+    return new RegExp(x)
+  });
 }
 
 sizes = adjustSourcePaths(sizes, !args['--noroot'], args['--replace'], args['--with']);

--- a/test.js
+++ b/test.js
@@ -37,5 +37,20 @@ describe('source-map-explorer', function() {
       expect(adjustSourcePaths({'/src/foo.js': 10, '/src/foodle.js': 20}, false, ['src'], ['dist']))
           .to.deep.equal({'/dist/foo.js': 10, '/dist/foodle.js': 20});
     });
+
+    it('should find/replace with regexp', function() {
+      expect(adjustSourcePaths({'/src/foo.js': 10, '/src/foodle.js': 20}, false, ['foo.'], ['bar.'], true))
+          .to.deep.equal({'/src/bar.js': 10, '/src/bar.le.js': 20});
+    });
+
+    it('should find/replace without regexp', function() {
+      expect(adjustSourcePaths({'/src/foo.js': 10, '/src/foodle.js': 20}, false, ['foo.'], ['bar.'], false))
+          .to.deep.equal({'/src/bar.js': 10, '/src/foodle.js': 20});
+    });
+
+    it('should find/replace with regexp, can be used to add root', function() {
+      expect(adjustSourcePaths({'/foo/foo.js': 10, '/foo/foodle.js': 20}, false, ['^/foo'], ['/bar'], true))
+          .to.deep.equal({'/bar/foo.js': 10, '/bar/foodle.js': 20});
+    });
   });
 });


### PR DESCRIPTION
In case you are interested I used this feature like this:

```sh
source-map-explorer --tsv --regex --replace "^" --with "components/"
```