### PR TITLE
Add loadSourceMap and computeGeneratedFileSizes to exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,6 +221,8 @@ open(tempName, function(error) {
 
 // Exports are here mostly for testing.
 module.exports = {
+  loadSourceMap: loadSourceMap,
+  computeGeneratedFileSizes: computeGeneratedFileSizes,
   adjustSourcePaths: adjustSourcePaths,
   mapKeys: mapKeys,
   commonPathPrefix: commonPathPrefix


### PR DESCRIPTION
This would allow me to generate tree-maps in my project without creating a child_process.