### PR TITLE
allow glob to match one file

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,9 +197,8 @@ function expandGlob(args) {
   var arg2 = args['<script.js.map>'];
   if (arg1 && !arg2) {
     var files = glob.sync(arg1);
-    if (files.length > 2) {
-      throw new Error(
-        'Glob should match exactly 2 files but matched ' + files.length + ' ' + arg1);
+    if (files.length === 1) {
+      args['<script.js>'] = files[0];
     } else if (files.length === 2) {
       // allow the JS and source map file to match in either order.
       if (files[0].indexOf('.map') >= 0) {
@@ -209,6 +208,9 @@ function expandGlob(args) {
       }
       args['<script.js>'] = files[0];
       args['<script.js.map>'] = files[1];
+    } else {
+      throw new Error(
+        'Glob should match exactly 1 or 2 files but matched ' + files.length + ' ' + arg1);
     }
   }
   return args;

--- a/test.js
+++ b/test.js
@@ -57,6 +57,10 @@ describe('source-map-explorer', function() {
       '<script.js.map>': 'testdata/foo.min.js.map'
     });
 
+    expect(expandGlob({'<script.js>': 'testdata/foo.min.inline*.js'})).to.deep.equal({
+      '<script.js>': 'testdata/foo.min.inline-map.js'
+    });
+
     expect(expandGlob({
       '<script.js>': 'foo.min.js',
       '<script.js.map>': 'foo.min.js.map'


### PR DESCRIPTION
This makes globbing behave same as `source-map-explorer single-file*.js` would in bash.

Fixes issue #79.