### PR TITLE
Combined bundle

### DIFF
--- a/tree-viz.ejs
+++ b/tree-viz.ejs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <link rel="stylesheet" href="data:text/css;base64,<%= webtreemapCss %>">


### PR DESCRIPTION
Here's the new default view when I run SME with four bundles: main, histogram, scatter and mapbox:
![image](https://user-images.githubusercontent.com/98301/51254897-11f7e100-1970-11e9-9ff5-6761d3832f3b.png)

Selecting a specific bundle from the dropdown or clicking it in the tree map have essentially the same behavior.

Also sets page language (Chrome kept offering to translate the result page from Danish!)

@nikolay-borzov let me know if you think this makes sense