### PR TITLE
Add node API to support multiple bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ node_modules
 
 # IDE
 .vscode
+
+# tmp files
+tmp/
+*.tmp.*

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,3 @@ node_modules
 
 # IDE
 .vscode
-
-# tmp files
-tmp/
-*.tmp.*

--- a/README.md
+++ b/README.md
@@ -100,6 +100,34 @@ require('source-map-explorer')('testdata/foo.min.js', { html: true })
 }
 ```
 
+### `exploreBundlesAndWriteHtml(writeConfig, codePath[, mapPath])`
+* `writeConfig` <[Object]> Configuration how to write the html file.
+  * `path` <[string]> Path to write.
+  * `fileName` <[string]> File name to write.
+* `codePath` <[string]> Path to bundle file or glob matching bundle files.
+* `mapPath` <[string]> Path to bundle map file.
+
+Example:
+
+```javascript
+const path = require('path')
+const {exploreBundlesAndWriteHtml} = require('source-map-explorer')
+
+const writePath = path.resolve(__dirname, 'this/path/will/be/ensured/to/exist/ok/thanks')
+const writeConfig = {
+  path: writePath, 
+  fileName: 'source.html'
+}
+
+exploreBundlesAndWriteHtml(writeConfig, 'build/static/js/*.*')
+  .then(() => { 
+    console.log(':)')
+  })
+  .catch(err => {
+    console.err(':(', err)
+  })
+```
+
 ## Generating source maps
 
 For source-map-explorer to be useful, you need to generate a source map which

--- a/index.js
+++ b/index.js
@@ -703,12 +703,12 @@ if (require.main === module) {
 
       const html = generateHtml(results);
 
-        if (exploreOptions.html) {
-          console.log(html);
-        } else {
-          writeToHtml(html);
-        }
-      });
+      if (exploreOptions.html) {
+        console.log(html);
+      } else {
+        writeToHtml(html);
+      }
+    });
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -694,9 +694,6 @@ if (require.main === module) {
 
     writeToHtml(data.html);
   } else {
-    // Do not generate HTML when exploring multiple bundles
-    exploreOptions.html = false;
-
     exploreBundlesAndFilterErroneous(bundles).then(results => {
       if (results.length === 0) {
         throw new Error('There were errors');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1317,6 +1317,16 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1415,8 +1425,7 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "growl": {
       "version": "1.10.5",
@@ -1886,6 +1895,14 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "kind-of": {
       "version": "6.0.2",
@@ -4370,6 +4387,11 @@
           }
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "convert-source-map": "^1.1.1",
     "docopt": "^0.6.2",
     "ejs": "^2.6.1",
+    "fs-extra": "^7.0.1",
     "glob": "^7.1.2",
     "opn": "^5.3.0",
     "source-map": "^0.5.1",

--- a/test.js
+++ b/test.js
@@ -9,7 +9,8 @@ const sourceMapExplorer = require('./index'),
   mapKeys = sourceMapExplorer.mapKeys,
   commonPathPrefix = sourceMapExplorer.commonPathPrefix,
   getBundles = sourceMapExplorer.getBundles;
-  exploreBundlesAndWriteHtml = sourceMapExplorer.exploreBundlesAndWriteHtml
+
+const exploreBundlesAndWriteHtml = sourceMapExplorer.exploreBundlesAndWriteHtml;
 
 const SCRIPT_PATH = './index.js';
 
@@ -101,8 +102,9 @@ describe('source-map-explorer', function() {
       expect(getBundles('testdata/*.*'), 'multiple bundles').to.deep.equal([
         {
           codePath: 'testdata/foo.1234.js',
-          mapPath: 'testdata/foo.1234.js.map'
-        }, {
+          mapPath: 'testdata/foo.1234.js.map',
+        },
+        {
           codePath: 'testdata/foo.min.inline-map.js',
           mapPath: undefined,
         },
@@ -118,17 +120,21 @@ describe('source-map-explorer', function() {
     });
 
     it('should support single file glob', () => {
-      expect(getBundles('testdata/foo.1*.js')).to.deep.equal([{
-        codePath: 'testdata/foo.1234.js',
-        mapPath: 'testdata/foo.1234.js.map'
-      }]);
+      expect(getBundles('testdata/foo.1*.js')).to.deep.equal([
+        {
+          codePath: 'testdata/foo.1234.js',
+          mapPath: 'testdata/foo.1234.js.map',
+        },
+      ]);
     });
 
     it('should support single file glob when inline map', () => {
-      expect(getBundles('testdata/foo.min.inline*.js'), 'single glob').to.deep.equal([{
-        codePath: 'testdata/foo.min.inline-map.js',
-        mapPath: undefined
-      }]);
+      expect(getBundles('testdata/foo.min.inline*.js'), 'single glob').to.deep.equal([
+        {
+          codePath: 'testdata/foo.min.inline-map.js',
+          mapPath: undefined,
+        },
+      ]);
     });
   });
 
@@ -280,36 +286,36 @@ describe('source-map-explorer', function() {
       function writeConfigToPath(writeConfig) {
         return writeConfig.path !== undefined
           ? `${writeConfig.path}/${writeConfig.fileName}`
-          : writeConfig.fileName
+          : writeConfig.fileName;
       }
 
       function expectBundleHtml(data) {
-        expect(data).to.to.be.a('string')
-        expect(data).to.have.string('<title>[combined] - Source Map Explorer</title>')
+        expect(data).to.to.be.a('string');
+        expect(data).to.have.string('<title>[combined] - Source Map Explorer</title>');
       }
 
       it('should explore multiple bundles and write a html file as specified in writeConfig', async () => {
-        const writePath = path.resolve(__dirname, 'tmp')
+        const writePath = path.resolve(__dirname, 'tmp');
         const writeConfig = {
-          path: writePath, 
-          fileName: 'bundle-out.tmp.html'
-        }
+          path: writePath,
+          fileName: 'bundle-out.tmp.html',
+        };
 
-        await exploreBundlesAndWriteHtml(writeConfig, 'testdata/*.*')
+        await exploreBundlesAndWriteHtml(writeConfig, 'testdata/*.*');
 
-        const data = fs.readFileSync(writeConfigToPath(writeConfig), 'utf8')
+        const data = fs.readFileSync(writeConfigToPath(writeConfig), 'utf8');
 
-        expectBundleHtml(data)
+        expectBundleHtml(data);
       });
 
       it('should explore multiple bundles and write a html file to current directory if path is undefined in writeConfig', async function() {
-        const writeConfig = {fileName: 'bundle-out.tmp.html'}
+        const writeConfig = { fileName: 'bundle-out.tmp.html' };
 
-        await exploreBundlesAndWriteHtml(writeConfig, 'testdata/*.*')
+        await exploreBundlesAndWriteHtml(writeConfig, 'testdata/*.*');
 
-        const data = fs.readFileSync(writeConfigToPath(writeConfig), 'utf8')
+        const data = fs.readFileSync(writeConfigToPath(writeConfig), 'utf8');
 
-        expectBundleHtml(data)
+        expectBundleHtml(data);
       });
     });
   });

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 const expect = require('chai').expect;
 const fs = require('fs');
+const path = require('path');
 
 const { execute } = require('./test-helpers');
 
@@ -8,6 +9,7 @@ const sourceMapExplorer = require('./index'),
   mapKeys = sourceMapExplorer.mapKeys,
   commonPathPrefix = sourceMapExplorer.commonPathPrefix,
   getBundles = sourceMapExplorer.getBundles;
+  exploreBundlesAndWriteHtml = sourceMapExplorer.exploreBundlesAndWriteHtml
 
 const SCRIPT_PATH = './index.js';
 
@@ -272,6 +274,43 @@ describe('source-map-explorer', function() {
       expect(function() {
         sourceMapExplorer('testdata/foo.min.no-map.js', 'testdata/foo.min.no-map.bad-map.js.map');
       }).to.throw('Your source map only contains one source (foo.min.js)');
+    });
+
+    describe('exploreBundlesAndWriteHtml method', function() {
+      function writeConfigToPath(writeConfig) {
+        return writeConfig.path !== undefined
+          ? `${writeConfig.path}/${writeConfig.fileName}`
+          : writeConfig.fileName
+      }
+
+      function expectBundleHtml(data) {
+        expect(data).to.to.be.a('string')
+        expect(data).to.have.string('<title>[combined] - Source Map Explorer</title>')
+      }
+
+      it('should explore multiple bundles and write a html file as specified in writeConfig', async () => {
+        const writePath = path.resolve(__dirname, 'tmp')
+        const writeConfig = {
+          path: writePath, 
+          fileName: 'bundle-out.tmp.html'
+        }
+
+        await exploreBundlesAndWriteHtml(writeConfig, 'testdata/*.*')
+
+        const data = fs.readFileSync(writeConfigToPath(writeConfig), 'utf8')
+
+        expectBundleHtml(data)
+      });
+
+      it('should explore multiple bundles and write a html file to current directory if path is undefined in writeConfig', async function() {
+        const writeConfig = {fileName: 'bundle-out.tmp.html'}
+
+        await exploreBundlesAndWriteHtml(writeConfig, 'testdata/*.*')
+
+        const data = fs.readFileSync(writeConfigToPath(writeConfig), 'utf8')
+
+        expectBundleHtml(data)
+      });
     });
   });
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 
 const { execute } = require('./test-helpers');
@@ -306,6 +306,8 @@ describe('source-map-explorer', function() {
         const data = fs.readFileSync(writeConfigToPath(writeConfig), 'utf8');
 
         expectBundleHtml(data);
+
+        fs.removeSync(writePath);
       });
 
       it('should explore multiple bundles and write a html file to current directory if path is undefined in writeConfig', async function() {
@@ -316,6 +318,8 @@ describe('source-map-explorer', function() {
         const data = fs.readFileSync(writeConfigToPath(writeConfig), 'utf8');
 
         expectBundleHtml(data);
+
+        fs.removeSync(writeConfig.fileName);
       });
     });
   });


### PR DESCRIPTION
As far as I understand (please correct me if I'm wrong) the current **node API** does not support multiple bundles, whereas the CLI exposes  this feature. 
Also, I think there is a [pending discussion](https://github.com/danvk/source-map-explorer/issues/25#issuecomment-453780294) on how to unify the current `explore` method to support multiple bundles. However, the issue was closed after exposing the feature via CLI.
Further, there is a lack of symmetry regarding the allowed `exploreOptions` for exploring multiple bundles.
The `exploreOptions` passed in [here](https://github.com/danvk/source-map-explorer/blob/master/index.js#L649) are ignored in [ `explorePromisified`](https://github.com/danvk/source-map-explorer/blob/master/index.js#L468). Basically, the CLI API for multiple bundles just allows writing to html. I've already proposed a quick [fix](https://github.com/danvk/source-map-explorer/pull/95) to solve the piping [issue](https://github.com/danvk/source-map-explorer/issues/89).

---

This PR proposes an addition to the **node API** to expose exploring multiple bundles and writing to html. Maybe, this PR could be a temporary solution until the a good solution is found for a unified explore method (supporting same amount of options) for single and multiple bundles.
Once a unified implementation is found, the new API method (`exploreBundlesAndWriteHtml`) could be deprecated with a note how to migrate to explore.