### PR TITLE
Normalize path arguments (#84)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -276,15 +276,13 @@ interface WriteConfig {
 /**
  * Explore multiple bundles and write html output to file.
  *
- * @param codePath Path to bundle file or glob matching bundle files
- * @param [mapPath] Path to bundle map file
+ * @param fileTokens List of file paths or glob patterns
  */
 export async function exploreBundlesAndWriteHtml(
   writeConfig: WriteConfig,
-  codePath: string,
-  mapPath?: string
+  fileTokens: string[]
 ): Promise<void> {
-  const bundles = getBundles(codePath, mapPath);
+  const bundles = getBundles(fileTokens);
 
   return exploreBundles(bundles).then(results => {
     const successResults = results.filter(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,8 +20,7 @@ interface Arguments {
 }
 
 function parseArguments(): Arguments {
-  // TODO: Use `middleware` to remove extra single quotes from positional arguments
-  return yargs
+  const argv = yargs
     .strict()
     .scriptName('source-map-explorer')
     .usage('Analyze and debug space usage through source maps.')
@@ -94,6 +93,12 @@ function parseArguments(): Arguments {
       return true;
     })
     .parse();
+
+  // Trim extra quotes
+  const quoteRegex = /'/g;
+  argv._ = argv._.map(path => path.replace(quoteRegex, ''));
+
+  return argv;
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -155,7 +155,7 @@ function writeToHtml(html?: string): void {
 if (require.main === module) {
   const argv = parseArguments();
 
-  const bundles = getBundles(argv._[0], argv._[1]);
+  const bundles = getBundles(argv._);
 
   if (bundles.length === 0) {
     throw new Error('No file(s) found');

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -123,7 +123,7 @@ describe('Public API', function() {
         fileName: 'bundle-out.tmp.html',
       };
 
-      await exploreBundlesAndWriteHtml(writeConfig, 'data/*.*');
+      await exploreBundlesAndWriteHtml(writeConfig, ['data/*.*']);
 
       const data = fs.readFileSync(writeConfigToPath(writeConfig), 'utf8');
 
@@ -135,7 +135,7 @@ describe('Public API', function() {
     it('should explore multiple bundles and write a html file to current directory if path is undefined in writeConfig', async function() {
       const writeConfig = { fileName: 'bundle-out.tmp.html' };
 
-      await exploreBundlesAndWriteHtml(writeConfig, 'data/*.*');
+      await exploreBundlesAndWriteHtml(writeConfig, ['data/*.*']);
 
       const data = fs.readFileSync(writeConfigToPath(writeConfig), 'utf8');
 

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -20,8 +20,8 @@ describe('CLI', function() {
     }
   });
 
-  it('should print result as JSON', async function() {
-    const result = await execute(SCRIPT_PATH, ['data/foo.min.inline-map.js', '--json']);
+  it('should print result as JSON and support path wrapped by quotes', async function() {
+    const result = await execute(SCRIPT_PATH, ["'data/foo.min.inline-map.js'", '--json']);
 
     expect(result).to.matchSnapshot();
   });

--- a/tests/cli.test.js.snap
+++ b/tests/cli.test.js.snap
@@ -85,7 +85,7 @@ exports[`CLI should output result as tsv 1`] = `
 "
 `;
 
-exports[`CLI should print result as JSON 1`] = `
+exports[`CLI should print result as JSON and support path wrapped by quotes 1`] = `
 "{
   \\"node_modules/browserify/node_modules/browser-pack/_prelude.js\\": 463,
   \\"dist/bar.js\\": 2854,

--- a/tests/common..test.js
+++ b/tests/common..test.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 
 import { getBundles } from '../src/common';
 
-describe('getBundles - command line parsing', function() {
+describe('getBundles - file tokens parsing', function() {
   const tests = [
     {
       name: 'should expand glob',
-      args: ['data/foo.min.js*'],
+      fileTokens: ['data/foo.min.js*'],
       expected: [
         {
           codePath: 'data/foo.min.js',
@@ -16,7 +16,7 @@ describe('getBundles - command line parsing', function() {
     },
     {
       name: 'should return one bundle if map file specified',
-      args: ['foo.min.js', 'foo.min.js.map'],
+      fileTokens: ['foo.min.js', 'foo.min.js.map'],
       expected: [
         {
           codePath: 'foo.min.js',
@@ -26,7 +26,7 @@ describe('getBundles - command line parsing', function() {
     },
     {
       name: 'should expand glob into all bundles in directory',
-      args: ['data/*.*'],
+      fileTokens: ['data/*.*'],
       expected: [
         {
           codePath: 'data/foo.1234.js',
@@ -47,8 +47,8 @@ describe('getBundles - command line parsing', function() {
       ],
     },
     {
-      name: 'should support single file glob',
-      args: ['data/foo.1*.js'],
+      name: 'should expand glob including .map files',
+      fileTokens: ['data/foo.1*.js'],
       expected: [
         {
           codePath: 'data/foo.1234.js',
@@ -57,8 +57,32 @@ describe('getBundles - command line parsing', function() {
       ],
     },
     {
+      name: 'should expand glob into code and map files',
+      fileTokens: ['data/foo.1*.js?(.map)'],
+      expected: [
+        {
+          codePath: 'data/foo.1234.js',
+          mapPath: 'data/foo.1234.js.map',
+        },
+      ],
+    },
+    {
+      name: 'should expand multiple globs',
+      fileTokens: ['data/foo.1*.js', 'data/foo.mi?.js'],
+      expected: [
+        {
+          codePath: 'data/foo.1234.js',
+          mapPath: 'data/foo.1234.js.map',
+        },
+        {
+          codePath: 'data/foo.min.js',
+          mapPath: 'data/foo.min.js.map',
+        },
+      ],
+    },
+    {
       name: 'should support single file glob when inline map',
-      args: ['data/foo.min.inline*.js'],
+      fileTokens: ['data/foo.min.inline*.js'],
       expected: [
         {
           codePath: 'data/foo.min.inline-map.js',
@@ -68,9 +92,9 @@ describe('getBundles - command line parsing', function() {
     },
   ];
 
-  tests.forEach(function({ name, args, expected }) {
+  tests.forEach(function({ name, fileTokens, expected }) {
     it(name, function() {
-      expect(getBundles(...args)).to.deep.equal(expected);
+      expect(getBundles(fileTokens)).to.deep.equal(expected);
     });
   });
 });


### PR DESCRIPTION
-Trim extra `'`
- Accept multiple file tokens - file names or globs
- Expand multiple globs

Resolves #84 #106