### PR TITLE
Fix temp file open error handling (#64)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "source-map-explorer",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1433,9 +1433,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.123",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
+      "version": "4.14.124",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.124.tgz",
+      "integrity": "sha512-6bKEUVbHJ8z34jisA7lseJZD2g31SIvee3cGX2KEZCS4XXWNbjPZpmO1/2rGNR9BhGtaYr6iYXPl1EzRrDAFTA==",
       "dev": true
     },
     "@types/minimatch": {
@@ -4323,9 +4323,9 @@
       }
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5900,6 +5900,20 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "source-map-explorer",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0",
   "description": "Analyze and debug space usage through source maps",
   "main": "dist/index.js",
   "bin": {
@@ -78,7 +78,7 @@
     "convert-source-map": "^1.6.0",
     "ejs": "^2.6.1",
     "escape-html": "^1.0.3",
-    "glob": "^7.1.3",
+    "glob": "^7.1.4",
     "lodash": "^4.17.11",
     "open": "^6.2.0",
     "source-map": "^0.7.3",
@@ -100,9 +100,8 @@
     "@types/convert-source-map": "^1.5.1",
     "@types/ejs": "^2.6.3",
     "@types/escape-html": "0.0.20",
-    "@types/fs-extra": "^5.0.5",
     "@types/glob": "^7.1.1",
-    "@types/lodash": "^4.14.123",
+    "@types/lodash": "^4.14.124",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.x",
     "@types/open": "^6.1.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import glob from 'glob';
-import { partition, flatMap } from 'lodash';
+import { partition, flatMap, isString } from 'lodash';
 
 import { generateHtml } from './html';
 import { exploreBundle, UNMAPPED_KEY } from './explore';
@@ -31,10 +31,7 @@ export async function explore(
   }
 
   // Separate bundles from file tokens
-  const [fileTokens, bundles] = partition(
-    bundlesAndFileTokens,
-    item => typeof item === 'string'
-  ) as [string[], Bundle[]];
+  const [fileTokens, bundles] = partition(bundlesAndFileTokens, isString);
 
   // Get bundles from file tokens
   bundles.push(...getBundles(fileTokens));
@@ -104,10 +101,10 @@ function getExploreResult(
   results: (ExploreBundleResult | ExploreErrorResult)[],
   options: ExploreOptions
 ): ExploreResult {
-  const [bundles, errors] = partition(results, result => 'files' in result) as [
-    ExploreBundleResult[],
-    ExploreErrorResult[]
-  ];
+  const [bundles, errors] = partition(
+    results,
+    (result): result is ExploreBundleResult => 'files' in result
+  );
 
   errors.push(...getPostExploreErrors(bundles));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,9 @@ export type ErrorCode =
   | 'NoSourceMap'
   | 'OneSourceSourceMap'
   | 'UnmappedBytes'
-  | 'CannotSaveFile';
+  | 'CannotSaveFile'
+  | 'CannotCreateTempFile'
+  | 'CannotOpenTempFile';
 
 export type File = string | Buffer;
 

--- a/tests/__snapshots__/app-error.test.ts.snap
+++ b/tests/__snapshots__/app-error.test.ts.snap
@@ -1,0 +1,36 @@
+exports['app-error getErrorMessage should create message for \'CannotCreateTempFile\' 1'] = `
+Unable to create a temporary HTML file
+`
+
+exports['app-error getErrorMessage should create message for \'CannotOpenTempFile\' 1'] = `
+Unable to open web browser. The system cannot find the file ?C:\\foo.htm
+Either run with --html, --json, --tsv, --file, or view HTML for the visualization at:
+C:\\foo.htm
+`
+
+exports['app-error getErrorMessage should create message for \'CannotSaveFile\' 1'] = `
+Unable to save HTML to file
+`
+
+exports['app-error getErrorMessage should create message for \'NoBundles\' 1'] = `
+No file(s) provided
+`
+
+exports['app-error getErrorMessage should create message for \'NoSourceMap\' 1'] = `
+Unable to find a source map.
+See https://github.com/danvk/source-map-explorer/blob/master/README.md#generating-source-maps
+`
+
+exports['app-error getErrorMessage should create message for \'OneSourceSourceMap\' 1'] = `
+Your source map only contains one source (foo.min.js).
+This can happen if you use browserify+uglifyjs, for example, and don't set the --in-source-map flag to uglify.
+See https://github.com/danvk/source-map-explorer/blob/master/README.md#generating-source-maps
+`
+
+exports['app-error getErrorMessage should create message for \'UnknownCode\' 1'] = `
+Unknown error
+`
+
+exports['app-error getErrorMessage should create message for \'UnmappedBytes\' 1'] = `
+Unable to map 70/100 bytes (70.00%)
+`

--- a/tests/app-error.test.ts
+++ b/tests/app-error.test.ts
@@ -1,0 +1,28 @@
+import snapshot from '@smpx/snap-shot-it';
+
+import { getErrorMessage } from '../src/app-error';
+
+describe('app-error', function() {
+  describe('getErrorMessage', function() {
+    const tests = [
+      { code: 'NoBundles' },
+      { code: 'NoSourceMap' },
+      { code: 'OneSourceSourceMap', filename: 'foo.min.js' },
+      { code: 'UnmappedBytes', totalBytes: 100, unmappedBytes: 70 },
+      { code: 'CannotSaveFile' },
+      { code: 'CannotCreateTempFile' },
+      {
+        code: 'CannotOpenTempFile',
+        error: Buffer.from('The system cannot find the file ?C:\\foo.htm'),
+        tempFile: 'C:\\foo.htm',
+      },
+      { code: 'UnknownCode' },
+    ];
+
+    tests.forEach(function(context) {
+      it(`should create message for '${context.code}'`, function() {
+        snapshot(getErrorMessage(context as any));
+      });
+    });
+  });
+});

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { getCommonPathPrefix } from '../src/helpers';
 
-describe('helpers', () => {
+describe('helpers', function() {
   describe('getCommonPathPrefix', function() {
     const tests = [
       { paths: ['abc', 'abcd', 'ab'], expected: '' },


### PR DESCRIPTION
- Fix error handling when temporary fail cannot be opened (e.g. because of access error). `catch` doesn't work since `open` always returns child process reference when `wait: false`. It should address #64
- Add `sme-result-` prefix to the temporary file.
- Add 2 app errors: `CannotCreateTempFile` and `CannotOpenTempFile` in order to separate creating and opening an temporary HTML file
- Update dependencies
- Prepare 2.0.0 version