### PR TITLE
Ignore coverage for inlined code 

### DIFF
--- a/tests/coverage.test.ts
+++ b/tests/coverage.test.ts
@@ -53,6 +53,26 @@ describe('coverage', () => {
       expect(bundles[3].coverageRanges).to.deep.equal([[{ start: 0, end: 5 }]]);
     });
 
+    it('should ignore coverage for inline code', () => {
+      const bundles: Bundle[] = [{ code: 'abc/ghi.js' }];
+
+      const coverages: Coverage[] = [
+        { url: 'http://my-site.io', ranges: [{ start: 0, end: 5 }], text: 'hijkl' },
+      ];
+
+      const coverageFileContent = JSON.stringify(coverages);
+
+      const { addCoverageRanges } = rewiremock.proxy('../src/coverage', r => ({
+        './helpers': r.callThrough().with({
+          getFileContent: () => coverageFileContent,
+        }),
+      }));
+
+      expect(() => {
+        addCoverageRanges(bundles, 'coverage.json');
+      }).to.throw('No matched bundles found for coverages');
+    });
+
     it('should convert one-line coverage range to per line ranges', () => {
       const tests = [
         {


### PR DESCRIPTION
In Chrome-generated coverage.json, scripts inlined to HTML doc will have the url of the HTML document.

Example: `{ url: "https://google.com/", ranges: [...] }`

When this happens, we ended up with an empty array inside `coveragePaths`. 
```
const coveragePaths = coverages.map(({ url }) => getPathParts(new URL(url).pathname || '').reverse())
```

This will cause the `for-loop` below to never be run; causing false positive because matchingBundles.length will equal to 1.
```
coveragePaths.forEach((partsA, coverageIndex) => {
      let matchingBundles = [...bundlesPaths];

      // Start from filename and go up to path root
      for (let i = 0; i < partsA.length; i++) {
        matchingBundles = matchingBundles.filter(
          ([partsB]) => i < partsB.length && partsB[i] === partsA[i]
        );

        // Stop when exact (among bundles) match found or no matches found
        if (matchingBundles.length <= 1) {
          break;
        }
      }

      if (matchingBundles.length === 1) {
        const [[, bundleIndex]] = matchingBundles;

        bundles[bundleIndex].coverageRanges = convertRangesToLinesRanges(coverages[coverageIndex]);
      }
    });
```