### PR TITLE
Expose functions

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -98,7 +98,7 @@ function onExploreError(bundle: Bundle, error: NodeJS.ErrnoException): ExploreEr
   };
 }
 
-function getExploreResult(
+export function getExploreResult(
   results: (ExploreBundleResult | ExploreErrorResult)[],
   options: ExploreOptions
 ): ExploreResult {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -188,7 +188,7 @@ function getExploreOptions(argv: Arguments): ExploreOptions {
 /**
  * Write HTML content to a temporary file and open the file in a browser
  */
-async function writeHtmlToTempFile(html?: string): Promise<void> {
+export async function writeHtmlToTempFile(html?: string): Promise<void> {
   if (!html) {
     return;
   }

--- a/src/explore.ts
+++ b/src/explore.ts
@@ -67,7 +67,7 @@ interface SourceMapData {
 /**
  * Get source map
  */
-async function loadSourceMap(codeFile: File, sourceMapFile?: File): Promise<SourceMapData> {
+export async function loadSourceMap(codeFile: File, sourceMapFile?: File): Promise<SourceMapData> {
   const codeFileContent = getFileContent(codeFile);
 
   let consumer: Consumer;
@@ -143,7 +143,7 @@ function checkInvalidMappingColumn({
 /**
  * Calculate the number of bytes contributed by each source file
  */
-function computeFileSizes(
+export function computeFileSizes(
   sourceMapData: SourceMapData,
   options: ExploreOptions,
   coverageRanges?: CoverageRange[][]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,25 @@
-import { explore } from './api';
-import { UNMAPPED_KEY, SOURCE_MAP_COMMENT_KEY, NO_SOURCE_KEY } from './explore';
+import { explore, getExploreResult } from './api';
+import { saveOutputToFile } from './output';
+import { writeHtmlToTempFile } from './cli';
+import {
+  loadSourceMap,
+  adjustSourcePaths,
+  UNMAPPED_KEY,
+  SOURCE_MAP_COMMENT_KEY,
+  NO_SOURCE_KEY,
+} from './explore';
 
-export { explore, UNMAPPED_KEY, SOURCE_MAP_COMMENT_KEY, NO_SOURCE_KEY };
+export {
+  explore,
+  getExploreResult,
+  loadSourceMap,
+  adjustSourcePaths,
+  saveOutputToFile,
+  writeHtmlToTempFile,
+  UNMAPPED_KEY,
+  SOURCE_MAP_COMMENT_KEY,
+  NO_SOURCE_KEY,
+};
 
 export default explore;
 


### PR DESCRIPTION
This PR is related top this issue #156 

We would like to use source-map-explorer with e.g RAM Bundles (more info in issue)
To minimize the amount of changes in the code we can just simply export a few of the functions that are used to calculate and present the data.
With those functions, we can go through the process of calculating and presenting ourselves  

### Changes
-export `getExploreResult`, `writeHtmlToTempFile`, `loadSourceMap` and `computeFileSizes` functions.