### PR TITLE
Fix coverages for inlined code exclusion

### DIFF
--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -88,7 +88,7 @@ export function addCoverageRanges(bundles: Bundle[], coverageFilename?: string):
       .map(({ url }) => getPathParts(new URL(url).pathname).reverse())
       .forEach((partsA, coverageIndex) => {
         // Exclude coverages for inlined code (URL doesn't contain a filename)
-        if (partsA.length < 1) return;
+        if (!partsA.length) return;
         let matchingBundles = [...bundlesPaths];
 
         // Start from filename and go up to path root

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -86,9 +86,9 @@ export function addCoverageRanges(bundles: Bundle[], coverageFilename?: string):
     coverages
       // pathname contains filename
       .map(({ url }) => getPathParts(new URL(url).pathname).reverse())
-      // Exclude coverages for inlined code (URL doesn't contain a filename)
-      .filter(pathParts => pathParts.length > 0)
       .forEach((partsA, coverageIndex) => {
+        // Exclude coverages for inlined code (URL doesn't contain a filename)
+        if (partsA.length < 1) return;
         let matchingBundles = [...bundlesPaths];
 
         // Start from filename and go up to path root


### PR DESCRIPTION
Hi, I very well might be missing something, but I believe using a `filter` to remove coverage entries with an empty "pathParts" array can interfere with the use of `coverageIndex` to index into the `coverages` array on line 110 of coverage.ts. 

Before I made this change, I was getting inconsistent and sometimes surprising coverage visualizations. After I made the change, the coverage visualizations aligned more closely with what I was seeing in the chrome devtools.

