### PR TITLE
Add link to bundle-wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,8 @@ source-map-explorer path/to/foo.min.js{,.map}
 
 [source-map-visualization](https://sokra.github.io/source-map-visualization)
 
+[bundle-wizard](https://github.com/aholachek/bundle-wizard): Easier analysis of webapp entry points (uses source-map-explorer under the hood)
+
 [demo]: https://cdn.rawgit.com/danvk/source-map-explorer/08b0e130cb9345f9061760bf8a8d9136ea60b457/demo.html
 [another demo]: https://cdn.rawgit.com/danvk/source-map-explorer/08b0e130cb9345f9061760bf8a8d9136ea60b457/demo-bug.html
 [browserify]: http://browserify.org/


### PR DESCRIPTION
Hi,

I [made a tool](https://github.com/aholachek/bundle-wizard) that that uses puppeteer to download js files, sourcemaps and coverage, before passing them into source-map-explorer. 

It also shows [a custom visualization](https://bundle-wizard.surge.sh/), and part of my motivation in making this was to make the visualization more to my liking, but I see that with prs [like this one](https://github.com/danvk/source-map-explorer/pull/162) you're working on improving the visualization too.

It definitely suffers from the slowdown [noted in this issue](https://github.com/danvk/source-map-explorer/issues/158) so will probably be more helpful as a tool whenever that is resolved.

No worries if this is not the type of thing you want to link in the readme!  
