### PR TITLE
Support Windows path separator

### DIFF
--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -111,6 +111,7 @@ function getNodePath(parts: string[], depthIndex: number): string {
 
 const WEBPACK_FILENAME_PREFIX = 'webpack:///';
 const WEBPACK_FILENAME_PREFIX_LENGTH = WEBPACK_FILENAME_PREFIX.length;
+const PATH_SEPARATOR_REGEX = /[\\/]/;
 
 function splitFilename(file: string): string[] {
   const webpackPrefixIndex = file.indexOf(WEBPACK_FILENAME_PREFIX);
@@ -124,7 +125,7 @@ function splitFilename(file: string): string[] {
     ].filter(Boolean);
   }
 
-  return file.split('/');
+  return file.split(PATH_SEPARATOR_REGEX);
 }
 
 function getTreeNodesMap(fileDataMap: FileDataMap): TreeNodesMap {

--- a/tests/unit/__snapshots__/html.test.ts.snap
+++ b/tests/unit/__snapshots__/html.test.ts.snap
@@ -134,6 +134,75 @@ exports['html getWebTreeMapData should collapse non-contributing nodes 1'] = {
   ]
 }
 
+exports['html getWebTreeMapData should merge mixed paths 1'] = {
+  "name": "/",
+  "data": {
+    "$area": 21
+  },
+  "children": [
+    {
+      "name": "c:",
+      "data": {
+        "$area": 21
+      },
+      "children": [
+        {
+          "name": "a/b/c.js",
+          "data": {
+            "$area": 1
+          }
+        },
+        {
+          "name": "d",
+          "data": {
+            "$area": 20
+          },
+          "children": [
+            {
+              "name": "e.js",
+              "data": {
+                "$area": 2
+              }
+            },
+            {
+              "name": "f.js",
+              "data": {
+                "$area": 3
+              }
+            },
+            {
+              "name": "g",
+              "data": {
+                "$area": 9
+              },
+              "children": [
+                {
+                  "name": "h.js",
+                  "data": {
+                    "$area": 4
+                  }
+                },
+                {
+                  "name": "i.js",
+                  "data": {
+                    "$area": 5
+                  }
+                }
+              ]
+            },
+            {
+              "name": "j/i.js",
+              "data": {
+                "$area": 6
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
 exports['html getWebTreeMapData should not create node for zero size files 1'] = {
   "name": "/",
   "data": {

--- a/tests/unit/html.test.ts
+++ b/tests/unit/html.test.ts
@@ -108,5 +108,18 @@ describe('html', () => {
 
       snapshot(getWebTreeMapData(fileDataMap));
     });
+
+    it('should merge mixed paths', () => {
+      const fileDataMap: FileDataMap = {
+        'c:/a/b/c.js': { size: 1 },
+        'c:\\d\\e.js': { size: 2 },
+        'c:/d/f.js': { size: 3 },
+        'c:\\d\\g\\h.js': { size: 4 },
+        'c:/d/g/i.js': { size: 5 },
+        'c:\\d\\j\\i.js': { size: 6 },
+      };
+
+      snapshot(getWebTreeMapData(fileDataMap));
+    });
   });
 });


### PR DESCRIPTION
Fixes #197

When generating HTML, split non-Webpack paths on either `\` or `/`